### PR TITLE
add qubes split-browser

### DIFF
--- a/etc/apparmor.d/home.tor-browser.firefox
+++ b/etc/apparmor.d/home.tor-browser.firefox
@@ -160,6 +160,11 @@
     /run/**/**/dconf/ rw,
     /run/**/**/dconf/** rw,
 
+    ## Split Browser for Qubes ##
+    /usr/share/split-browser-disp/firefox/sb-load.js r,
+    /run/split-browser-disp/into-firefox rw,
+    /run/split-browser-disp/from-firefox w,
+
     # Site-specific additions and overrides. See local/README for details.
     #include <local/home.tor-browser.firefox>
 }


### PR DESCRIPTION
As talked in [this split-browser issue](https://github.com/rustybird/qubes-app-split-browser/issues/5): add rules to allow adding and loading bookmarks and logging into pages.